### PR TITLE
Chore/ruff cleanup

### DIFF
--- a/src/ChargedMotion.py
+++ b/src/ChargedMotion.py
@@ -5,63 +5,68 @@ Created on Mon Aug 24 15:10:38 2020
 
 @author: michele
 """
-import numpy as np 
+
+import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 from mpl_toolkits import mplot3d
 from Equilibrium import *
 from scipy import interpolate
-matplotlib.rcParams.update({'font.size': 24, 'font.family': 'serif', 'mathtext.fontset': 'stix'})
+
+matplotlib.rcParams.update({"font.size": 24, "font.family": "serif", "mathtext.fontset": "stix"})
+
 
 class Particle:
     """
     Class for the representation of the charged particle to be tracked
     """
+
     def __init__(self, Z, m, dt):
         """
         Constructor function
-        
+
         Input:
             Z (int) atomic number of the particle
             m (float) mass of the particle
         """
-        self.__e = -1.6E-19
+        self.__e = -1.6e-19
         self.q = Z * self.__e
         self.m = m
         self.dt = dt
-        self.Omega = -self.q * self.dt / self.m 
+        self.Omega = -self.q * self.dt / self.m
+
     def updateParticleState(self, x, v):
         """
         Method for updating the particle position
         Input:
             x0 (float) initial position of the particle
-        Return: 
+        Return:
             x (float) final position of the particle
-            
+
         """
         self.x0 = x
         self.v0 = v
-    
+
     def initializeParticleState(self, x0, v0):
         """
         Method for the initialization of the particle state
         """
         self.x0 = x0
         self.v0 = v0
-    
+
     def initializeSimulationDomain(self, xmin, xmax, ymin, ymax):
         """
-        Function for the initialization of the simulation domain 
+        Function for the initialization of the simulation domain
         """
-        self.xmin = xmin 
+        self.xmin = xmin
         self.xmax = xmax
-        self.ymin = ymin 
+        self.ymin = ymin
         self.ymax = ymax
-        
+
     def checkBoundaries(self):
         """
-        Method for applying the boundary conditions 
+        Method for applying the boundary conditions
         """
         xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
         if x0[0, 0] >= xmax:
@@ -80,15 +85,14 @@ class Particle:
             x0[1, 0] = ymin
             v0[1, 0] = -v0[1, 0]
             self.initializeParticleState(x0, v0)
-        
-    
+
     def printProperties(self):
         """
         Function for prnting the particle properties, i.e. charge and mass
         """
-        print('Particle charge {}: \nParticle mass {}'.format(self.q, self.m))
+        print("Particle charge {}: \nParticle mass {}".format(self.q, self.m))
 
-        
+
 class ParticlePusher:
     def __init__(self, mag, particle):
         """
@@ -96,36 +100,45 @@ class ParticlePusher:
         """
         self.mag = mag
         self.particle = particle
+
     def borishPush(self):
         """
         Method which implements the Boris algorithm for particle motion in a given EM field
         """
         particle = self.particle
         particle.checkBoundaries()
-        x0, v0, Omega, q, m = self.particle.x0, self.particle.v0, self.particle.Omega, self.particle.q, self.particle.m
+        x0, v0, Omega, q, m = (
+            self.particle.x0,
+            self.particle.v0,
+            self.particle.Omega,
+            self.particle.q,
+            self.particle.m,
+        )
         Bx, By = self.mag.InterpField(particle.x0)
-        Bz = np.array(0.)
-        E = np.array([[0., 0., 0.]]).T
-        P = np.array(((0., Bz, -By[0, 0]), (-Bz, 0., Bx[0, 0]), (By[0, 0], -Bx[0, 0], 0.)))
-        v = np.linalg.inv(np.eye(3) + Omega * P / 2.).dot(np.eye(3) - Omega * P / 2.).dot(v0) + np.linalg.inv(np.eye(3) + Omega * P / 2.).dot(q / m * dt * E)
+        Bz = np.array(0.0)
+        E = np.array([[0.0, 0.0, 0.0]]).T
+        P = np.array(((0.0, Bz, -By[0, 0]), (-Bz, 0.0, Bx[0, 0]), (By[0, 0], -Bx[0, 0], 0.0)))
+        v = np.linalg.inv(np.eye(3) + Omega * P / 2.0).dot(np.eye(3) - Omega * P / 2.0).dot(
+            v0
+        ) + np.linalg.inv(np.eye(3) + Omega * P / 2.0).dot(q / m * dt * E)
         x = x0 + v * dt
         particle.updateParticleState(x, v)
-        
-        
-        
+
+
 class MagneticField(Equilibrium):
     """
     Class for the representation of the magnetic field. Child class of the Equilibrum one
     """
+
     def __init__(self, r1, r2, z1, z2, Nr, Nz):
         """
-        Initialize the equilibrium 
+        Initialize the equilibrium
         """
         Equilibrium.__init__(self, r1, r2, z1, z2, Nr, Nz)
-    
+
     def InterpField(self, x0):
         """
-        Function for the interpolation of the magnetic field at the position x0 
+        Function for the interpolation of the magnetic field at the position x0
         """
         Bx, By, Z, R = self.Br, self.Bz, self.Z, self.R
         BxInterp = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], Bx)
@@ -133,17 +146,13 @@ class MagneticField(Equilibrium):
         BxPos = BxInterp(x0[1, 0], x0[0, 0])
         ByPos = ByInterp(x0[1, 0], x0[0, 0])
         return BxPos, ByPos
-    
-        
-        
-        
 
-    
+
 # Charged particle motion in a given magnetic field
 
-r1 = 1.0E-8 
-r2 = 0.125 
-z1 = 0.5 
+r1 = 1.0e-8
+r2 = 0.125
+z1 = 0.5
 z2 = 2.5
 Nr = 105
 Nz = 105
@@ -152,9 +161,9 @@ Nz = 105
 # # PlotEq.PlotPsiContour()
 # X = Eq.R
 # Y = Eq.Z
-v0 = np.array([[10., 10., 0.]]).T
-x0 = np.array([[0.07, 1.5, 0.]]).T
-dt = 1.0E-4
+v0 = np.array([[10.0, 10.0, 0.0]]).T
+x0 = np.array([[0.07, 1.5, 0.0]]).T
+dt = 1.0e-4
 Nstep = 1000
 Npart = 1
 # fig = plt.figure()
@@ -168,9 +177,9 @@ vy = np.empty((Nstep, Npart))
 vz = np.empty((Nstep, Npart))
 mag = MagneticField(r1, r2, z1, z2, Nr, Nz)
 for jj in range(0, Npart):
-    v0 = np.array([[1., 1., 10.]]).T
+    v0 = np.array([[1.0, 1.0, 10.0]]).T
     x0 = np.array([[0.001, 1.25, 0.01]]).T
-    particle = Particle(1, 9.11E-25, dt)
+    particle = Particle(1, 9.11e-25, dt)
     particle.initializeParticleState(x0, v0)
     particle.initializeSimulationDomain(r1, r2, z1, z2)
     particlePusher = ParticlePusher(mag, particle)
@@ -191,14 +200,14 @@ for jj in range(0, Npart):
 # PlotEq.PlotPsiContour()
 fig = plt.figure()
 ax = fig.gca()
-for jj in range(0, Npart):    
-    ax.plot(xx[:, jj], xy[:, jj], xz[:, jj], linewidth = 0.5)
-#ax.contour(Eq.R, Eq.Z, Eq.psi)
+for jj in range(0, Npart):
+    ax.plot(xx[:, jj], xy[:, jj], xz[:, jj], linewidth=0.5)
+# ax.contour(Eq.R, Eq.Z, Eq.psi)
 plt.show()
-r = np.sqrt(xx ** 2 + xz ** 2)
+r = np.sqrt(xx**2 + xz**2)
 theta = np.arctan2(xz, xx)
 fig = plt.figure()
-plt.polar(xz * 180. / np.pi, xx, linewidth = 0.1)
+plt.polar(xz * 180.0 / np.pi, xx, linewidth=0.1)
 plt.show()
 """
 Plot bello
@@ -206,35 +215,40 @@ Plot bello
 fig = plt.figure()
 ax = fig.gca()
 for jj in range(0, Npart):
-    ax.plot(xy[:, jj], xx[:, jj], 'grey', linewidth = 0.3) # Plot particle position in the x,y plane
-#ContourLevels = np.linspace(np.sqrt(np.abs(Eq.psi.min())), np.sqrt(Eq.psi.max()), 50)
+    ax.plot(xy[:, jj], xx[:, jj], "grey", linewidth=0.3)  # Plot particle position in the x,y plane
+# ContourLevels = np.linspace(np.sqrt(np.abs(Eq.psi.min())), np.sqrt(Eq.psi.max()), 50)
 ContourLevels = np.linspace(np.sqrt(np.abs(mag.psi.min())), 0, 25)
 ContourLevelsPos = np.linspace(0, np.sqrt(mag.psi.max()), 25)
-cnt = ax.contour(mag.R, mag.Z, mag.psi, -ContourLevels ** 2, cmap=matplotlib.cm.RdGy, linewidths = 1.0)
-cnt = ax.contour(mag.R, mag.Z, mag.psi, ContourLevelsPos ** 2, cmap=matplotlib.cm.RdGy, linewidths = 1.0)
+cnt = ax.contour(
+    mag.R, mag.Z, mag.psi, -(ContourLevels**2), cmap=matplotlib.cm.RdGy, linewidths=1.0
+)
+cnt = ax.contour(
+    mag.R, mag.Z, mag.psi, ContourLevelsPos**2, cmap=matplotlib.cm.RdGy, linewidths=1.0
+)
 plt.show()
 
 # 3d plot trajectory
 fig = plt.figure()
-ax = plt.axes(projection='3d')
+ax = plt.axes(projection="3d")
 ax.grid(False)
-for jj in range(0, Npart):    
-    ax.plot(xx[:, jj], xy[:, jj], xz[:, jj], 'grey', linewidth = 0.5)
+for jj in range(0, Npart):
+    ax.plot(xx[:, jj], xy[:, jj], xz[:, jj], "grey", linewidth=0.5)
 ContourLevels = np.linspace(np.sqrt(np.abs(mag.psi.min())), 0, 25)
 ContourLevelsPos = np.linspace(0, np.sqrt(mag.psi.max()), 25)
-cnt = ax.contour(mag.R, mag.Z, mag.psi, -ContourLevels ** 2, cmap=matplotlib.cm.RdGy, linewidths = 0.8)
-cnt = ax.contour(mag.R, mag.Z, mag.psi, ContourLevelsPos ** 2, cmap=matplotlib.cm.RdGy, linewidths = 0.8)
+cnt = ax.contour(
+    mag.R, mag.Z, mag.psi, -(ContourLevels**2), cmap=matplotlib.cm.RdGy, linewidths=0.8
+)
+cnt = ax.contour(
+    mag.R, mag.Z, mag.psi, ContourLevelsPos**2, cmap=matplotlib.cm.RdGy, linewidths=0.8
+)
 ax.set_xticks([])
 ax.set_yticks([])
 ax.set_zticks([])
 plt.show()
 # Guiding centre
-B = np.array([mag.Br, mag.Bz, 0.])
+B = np.array([mag.Br, mag.Bz, 0.0])
 b = B / np.linalg.norm(B)
-e = -1.6E-19
-me = 9.11E-25
+e = -1.6e-19
+me = 9.11e-25
 Omega = e * B / me
-R = x - (1. / Omega) * np.cross(b, v)
-
-
-
+R = x - (1.0 / Omega) * np.cross(b, v)

--- a/src/ChargedMotion.py
+++ b/src/ChargedMotion.py
@@ -8,9 +8,10 @@ Created on Mon Aug 24 15:10:38 2020
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+import scipy.interpolate
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
-from Equilibrium import *
+from Equilibrium import Equilibrium
 
 matplotlib.rcParams.update({"font.size": 24, "font.family": "serif", "mathtext.fontset": "stix"})
 

--- a/src/ChargedMotion.py
+++ b/src/ChargedMotion.py
@@ -1,18 +1,16 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Mon Aug 24 15:10:38 2020
 
 @author: michele
 """
 
-import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
-from mpl_toolkits import mplot3d
+
 from Equilibrium import *
-from scipy import interpolate
 
 matplotlib.rcParams.update({"font.size": 24, "font.family": "serif", "mathtext.fontset": "stix"})
 
@@ -90,7 +88,7 @@ class Particle:
         """
         Function for prnting the particle properties, i.e. charge and mass
         """
-        print("Particle charge {}: \nParticle mass {}".format(self.q, self.m))
+        print(f"Particle charge {self.q}: \nParticle mass {self.m}")
 
 
 class ParticlePusher:

--- a/src/Equilibrium.py
+++ b/src/Equilibrium.py
@@ -138,7 +138,7 @@ class Equilibrium:
                         * ((mu0 / (2 * np.pi)) * np.sqrt(R * Rc[kk, mm]) / k)
                         * ((2 - k2) * K - 2 * E)
                     )
-            psi_coil[:, :, ll] = np.trapz(np.trapz(G, zc), rc)
+            psi_coil[:, :, ll] = np.trapezoid(np.trapezoid(G, zc), rc)
         psi = psi_coil.sum(axis=2)
         return psi
 
@@ -253,7 +253,7 @@ class Mesh:
         return InterpPsi.T
 
     def InterpolateField(self, rQuery, MESH):
-        psi, Bz, R, Z, n, m = self.Eq.psi, self.Eq.Bz, self.Eq.R, self.Eq.Z, self.n, self.m
+        Bz, R, Z, n, m = self.Eq.Bz, self.Eq.R, self.Eq.Z, self.n, self.m
         zQuery = MESH[:, 3]
         BzC = np.zeros(n * (m + 2))
         InterpFunc = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], Bz)
@@ -276,7 +276,10 @@ class Mesh:
         rValues = R[0, :]
         alpha = 1.8
         overshoot = 1.0e-05
-        func = lambda x: z2 * ((np.tanh(-x)) / (np.tanh(alpha)) * (1 + overshoot)) / (1 + overshoot)
+
+        def func(x):
+            return z2 * ((np.tanh(-x)) / (np.tanh(alpha)) * (1 + overshoot)) / (1 + overshoot)
+
         IndexFunc = np.linspace(-alpha, alpha, 2 * n + 1)
         zQuery = func(IndexFunc)
         InterpPsi = Mesh.InterpolatePsi(self, zValues, rValues, zQuery, ContourLevels)
@@ -389,14 +392,14 @@ class PlotEquilibrium:
         )
         ax.set_xlabel("R [m]")
         ax.set_ylabel("Z [m]")
-        cb = fig.colorbar(cnt, ax=ax)
+        fig.colorbar(cnt, ax=ax)
         # plt.show()
 
     def PlotBContour(self):
         """
         Contour plot of B
         """
-        R, Z, Br, Bz, Ncont = self.Equ.R, self.Equ.Z, self.Equ.Br, self.Equ.Bz, self.Ncont
+        R, Z, Ncont = self.Equ.R, self.Equ.Z, self.Ncont
         B = np.sqrt(self.Equ.Br**2 + self.Equ.Bz**2)
         fig, ax = plt.subplots()
         cnt = ax.contourf(
@@ -404,18 +407,16 @@ class PlotEquilibrium:
         )
         ax.set_xlabel("R [m]")
         ax.set_ylabel("Z [m]")
-        cb = fig.colorbar(cnt, ax=ax)
+        fig.colorbar(cnt, ax=ax)
         plt.show()
 
     def PlotPsiBContour(self):
         """
         Plot psi and B contour on the same figure
         """
-        R, Z, Br, Bz, psi, Ncont = (
+        R, Z, psi, Ncont = (
             self.Equ.R,
             self.Equ.Z,
-            self.Equ.Br,
-            self.Equ.Bz,
             self.Equ.psi,
             self.Ncont,
         )
@@ -430,13 +431,13 @@ class PlotEquilibrium:
             vmin=abs(psi).min(),
             vmax=abs(psi).max(),
         )
-        cb = fig.colorbar(cntPsi, ax=ax[0])
+        fig.colorbar(cntPsi, ax=ax[0])
         ax[0].set_xlabel("R [m]")
         ax[0].set_ylabel("Z [m]")
         cntB = ax[1].contourf(
             R, Z, B, Ncont, cmap=matplotlib.cm.RdGy, vmin=abs(B).min(), vmax=abs(B).max()
         )
-        cb = fig.colorbar(cntB, ax=ax[1])
+        fig.colorbar(cntB, ax=ax[1])
         ax[1].set_xlabel("R [m]")
         ax[1].set_ylabel("Z [m]")
         plt.show()
@@ -500,16 +501,10 @@ class Resonances:
 
     def LocateAxial(self):
         """Method for the computation of the axial location of the resonace"""
-        OmegaInj, Br, Bz, psi, R, Z, e, me, mi, OmegaCE = (
+        OmegaInj, R, Z, OmegaCE = (
             self.OmegaInj,
-            self.Eq.Br,
-            self.Eq.Bz,
-            self.Eq.psi,
             self.Eq.R,
             self.Eq.Z,
-            self.__e,
-            self.__me,
-            self.__mi,
             self.OmegaCE,
         )
         cs = plt.contour(R[0, :], Z[:, 0], OmegaCE, [OmegaInj])
@@ -662,17 +657,13 @@ class Sources:
         self.AxialPoints = Sources.ComputeAxialPoints(self)
 
     def ComputeRadialPoints(self):
-        AxialResPosition, Mesh, n, zmin, zmax = (
-            self.Res.ZResPosition,
+        Mesh, n, zmin, zmax = (
             self.Grid.Mesh,
             self.Grid.n,
             self.zmin,
             self.zmax,
         )
         Shape = np.shape(Mesh)
-        Toll = AxialResPosition * 1.1
-        zMin = AxialResPosition - Toll
-        zMax = AxialResPosition + Toll
         RcentrePoints = Mesh[0 : Shape[0], 2]
         ZcentrePoints = Mesh[0 : Shape[0], 3]
         ZonAxis = ZcentrePoints[0:n]
@@ -693,7 +684,8 @@ class Sources:
         return AxialPoints
 
     def WriteSource(self):
+        # TODO: complete WriteSource implementation (writes source term to file for edge plasma codes)
         RadialPoints, AxialPoints = self.RadialPoints, self.AxialPoints
-        RadialValues = self.RadialDensity(RadialPoints)
-        AxialValues = self.AxialDensity(AxialPoints)
-        l = np.size(RadialPoints)
+        RadialValues = self.RadialDensity(RadialPoints)  # noqa: F841
+        AxialValues = self.AxialDensity(AxialPoints)  # noqa: F841
+        l = np.size(RadialPoints)  # noqa: F841

--- a/src/Equilibrium.py
+++ b/src/Equilibrium.py
@@ -1,11 +1,11 @@
-import numpy as np
-import scipy
-from scipy import interpolate
-from scipy.special import ellipk, ellipe
 import matplotlib
-import numpy.matlib
 import matplotlib.pyplot as plt
+import numpy as np
+import numpy.matlib
+import scipy
 import scipy.interpolate
+from scipy import interpolate
+from scipy.special import ellipe, ellipk
 
 matplotlib.rcParams.update({"font.size": 18, "font.family": "serif", "mathtext.fontset": "stix"})
 
@@ -533,15 +533,15 @@ class Resonances:
         )
         fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(10, 10))
         ax[0].contour(R[0, :], Z[:, 0], OmegaCE, [OmegaInj])
-        ax[0].set_title("$\Omega_{CE}$")
+        ax[0].set_title(r"$\Omega_{CE}$")
         ax[0].set_xlabel("R [m]")
         ax[0].set_ylabel("Z [m]")
         ax[1].contour(R[0, :], Z[:, 0], OmegaUH, [OmegaInj])
-        ax[1].set_title("$\Omega_{UH}$")
+        ax[1].set_title(r"$\Omega_{UH}$")
         ax[1].set_xlabel("R [m]")
         ax[1].set_ylabel("Z [m]")
         ax[2].contour(R[0, :], Z[:, 0], OmegaLH, [OmegaInj])
-        ax[2].set_title("$\Omega_{LH}$")
+        ax[2].set_title(r"$\Omega_{LH}$")
         ax[2].set_xlabel("R [m]")
         ax[2].set_ylabel("Z [m]")
         plt.show()
@@ -560,11 +560,11 @@ class Resonances:
         )
         fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(10, 10))
         ax[0].contour(R[0, :], Z[:, 0], OmegaC1, [OmegaInj])
-        ax[0].set_title("$\Omega_{C1}$")
+        ax[0].set_title(r"$\Omega_{C1}$")
         ax[0].set_xlabel("R [m]")
         ax[0].set_ylabel("Z [m]")
         ax[1].contour(R[0, :], Z[:, 0], OmegaC2, [OmegaInj])
-        ax[1].set_title("$\Omega_{C2}$")
+        ax[1].set_title(r"$\Omega_{C2}$")
         ax[1].set_xlabel("R [m]")
         ax[1].set_ylabel("Z [m]")
         fig.tight_layout()
@@ -615,7 +615,7 @@ class Resonances:
         Zc = Zc.reshape(m + 2, n)
         fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(10, 10))
         ax[0].contour(Rc, Zc, OmegaCEGrid, [OmegaInj])
-        ax[0].set_title("$\Omega_{CE}$")
+        ax[0].set_title(r"$\Omega_{CE}$")
         ax[0].set_xlabel("R [m]")
         ax[0].set_ylabel("Z [m]")
         for ii in range(0, m + 3):
@@ -625,7 +625,7 @@ class Resonances:
             Points = Points + n * 5
         Points = n * 5
         ax[1].contour(Rc, Zc, OmegaUHGrid, [OmegaInj])
-        ax[1].set_title("$\Omega_{UH}$")
+        ax[1].set_title(r"$\Omega_{UH}$")
         ax[1].set_xlabel("R [m]")
         ax[1].set_ylabel("Z [m]")
         for ii in range(0, m + 3):
@@ -635,7 +635,7 @@ class Resonances:
             Points = Points + n * 5
         Points = n * 5
         ax[2].contour(Rc, Zc, OmegaLHGrid, [OmegaInj])
-        ax[2].set_title("$\Omega_{LH}$")
+        ax[2].set_title(r"$\Omega_{LH}$")
         ax[2].set_xlabel("R [m]")
         ax[2].set_ylabel("Z [m]")
         for ii in range(0, m + 3):

--- a/src/Equilibrium.py
+++ b/src/Equilibrium.py
@@ -6,529 +6,694 @@ import matplotlib
 import numpy.matlib
 import matplotlib.pyplot as plt
 import scipy.interpolate
-matplotlib.rcParams.update({'font.size': 18, 'font.family': 'serif', 'mathtext.fontset': 'stix'})
 
-class Coils: 
-	""" 
-	Class for the representation of the external magnetic field coils
-	
-	Args: 
-		coilName (str): path to the file containing coil data
-	
-	Return:
-		Jc (array): np.array of length Ncoils containting current density flowing into each coil
-	"""
-	def __init__(self, coilName):
-		""" 
-		Initialise the main coil properties starting from a .txt file
-		""" 
-		CoilParam = np.loadtxt(coilName)
-		self.Ncoils = np.shape(CoilParam)[1]
-		self.Rc1 = CoilParam[0, :]
-		self.Zc1 = CoilParam[1, :]
-		self.Rc2 = CoilParam[2, :]
-		self.Zc2 = CoilParam[3, :]
-		self.Ic = CoilParam[4, :]
-		self.Jc = Coils.ComputeCurrents(self)
-	@classmethod
-	def from_keyboard(cls):
-		coilName = input('Insert coil file name:')
-		coilName = "/Users/michele/Desktop/LPDEquilibria/Coils/" + coilName 
-		Coils.__init__(cls, coilName)
-		return cls
-	def ComputeCurrents(self):
-		"""
-		Compute the coils current density, assuming that the coil is a square
-		"""
-		Jc = np.zeros(self.Ncoils)
-		Jc = self.Ic / ( (self.Rc2 - self.Rc1) * (self.Zc2 - self.Zc1) )
-		return Jc
+matplotlib.rcParams.update({"font.size": 18, "font.family": "serif", "mathtext.fontset": "stix"})
 
 
-class Equilibrium: 
-	""" 
-	Class to represent the Equilibrium of the machine on a [r1, r2]x[z1, z2] grid
-	
-	Args: 
-		r1 (float): lower boundary of the computational domain in the r direction
-		r2 (float): upper boundary of the computational domain in the r direction
-		z1 (float): lower boundary of the computational domain in the z direction
-		z2 (float): upper boundary of the computational domain in the z direction 
-		Nr (int): Number of points in the radial direction 
-		Nz (int): Number of points in the axial direction
-		R (float): numpy NrxNz array
-		Z (float): numpy NrxNz array 
-		psi (float): numpy NrxNz array containing the stream function 
-		Br (float): numpy NrxNz array containing the r component of the magnetic field
-		Bz (float): numpy NrxNz array containing the z component of the magnetic fieldq
-	
-	Return:
-		Eq (object)
-	"""
-	def __init__(self, r1, r2, z1, z2, Nr, Nz, Nc = 10):
-		self.__mu0 = 4 * np.pi * 1.0E-07
-		self.r1 = r1
-		self.r2 = r2
-		self.z1 = z1
-		self.z2 = z2
-		self.Nr = Nr
-		self.Nz = Nz
-		self.Nc = Nc
-		self.Coil = Coils.from_keyboard()
-		R, Z = Equilibrium.BuildGrid(self)
-		self.R = R
-		self.Z = Z
-		self.psi = Equilibrium.ComputePsi(self)
-		Br, Bz = Equilibrium.ComputeField(self)
-		self.Br = Br
-		self.Bz = Bz
-	def BuildGrid(self):
-		"""
-		Construct cartesian grid in the (R, Z) plane necessary for the computation of the equilibrium 
-		"""
-		r1, r2, z1, z2, Nr, Nz = self.r1, self.r2, self.z1, self.z2, self.Nr, self.Nz
-		r = np.linspace(r1, r2, Nr)
-		z = np.linspace(z1, z2, Nz)
-		R, Z = np.meshgrid(r, z)
-		return R, Z
-	def BuildGridCoils(self, index):
-		"""
-		Compute a cartesian grid on each of the (index) coil with a predefined (Nc=10) number of points
-		""" 
-		Rc1, Rc2, Zc1, Zc2, Nc = self.Coil.Rc1, self.Coil.Rc2, self.Coil.Zc1, self.Coil.Zc2, self.Nc
-		zc = np.linspace(Zc2[index], Zc1[index], Nc)
-		rc = np.linspace(Rc2[index], Rc1[index], Nc)
-		Rc, Zc = np.meshgrid(rc, zc)
-		return Rc, Zc, rc, zc
-	def ComputePsi(self):
-		"""
-		Compute the poloidal flux function using the Green Function method of the Grad-Shafranov Equation
-		"""
-		R, Z, Nr, Nz, Nc, Jc, Ncoil, mu0 = self.R, self.Z, self.Nr, self.Nz, self.Nc, self.Coil.Jc, self.Coil.Ncoils, self.__mu0
-		psi_coil = np.zeros((Nz, Nr, Ncoil))
-		for ll in range(0, Ncoil):
-			G = np.zeros((Nz, Nr, Nc, Nc))
-			Rc, Zc, rc, zc = Equilibrium.BuildGridCoils(self, ll)
-			for kk in range(0, Nc):
-				for mm in range(0, Nc):
-					k2 = ( 4.0 * R * Rc[kk,mm] ) / ( (R + Rc[kk,mm]) ** 2 + (Z - Zc[kk,mm]) ** 2)
-					k = np.sqrt(k2)
-					K = ellipk(k2)
-					E = ellipe(k2)
-					G[:, :, kk,mm] = Jc[ll] * ((mu0 / ( 2 * np.pi)) * np.sqrt( R * Rc[kk,mm]) / k ) * ( (2 - k2) * K - 2 * E)
-			psi_coil[:,:,ll] = np.trapz(np.trapz(G, zc), rc)         
-		psi = psi_coil.sum(axis = 2)
-		return psi
-	def ComputeField(self):
-		"""
-		Function for the computation of the radial and axial magnetic field components
-		""" 
-		Nr, Nz, r2, r1, z2, z1, psi, R = self.Nr, self.Nz, self.r2, self.r1, self.z2, self.z1, self.psi, self.R
-		Br = np.zeros((Nz, Nr))
-		Bz = np.zeros((Nz, Nr))
-		dr = (r2 - r1) / (Nr - 1)
-		dz = (z2 - z1) / (Nz - 1)
-		# Compute the axial magnetic field
-		for ii in range(0, Nz):
-			for jj in range(0, Nr):
-				if jj == 0:
-					Bz[ii, jj] = 2 * (psi[ii,jj + 1] - psi[ii, jj]) / (dr*dr)
-				elif jj == Nr - 1:
-					Bz[ii, jj] = (psi[ii,jj] - psi[ii,jj - 1]) / dr
-					Bz[ii, jj] = Bz[ii, jj] / R[ii,jj]
-				else:
-					Bz[ii,jj] = (psi[ii, jj + 1] - psi[ii, jj - 1]) / (2 * dr)
-					Bz[ii,jj] =  Bz[ii, jj] / R[ii,jj]
-		# Compute the radial magnetic field
-		for ii in range(0, Nz):
-			for jj in range(0, Nr):
-				if ii == 0:
-					Br[ii, jj] = (psi[ii + 1, jj] - psi[ii, jj]) / dz
-				elif ii == Nz - 1:
-					Br[ii, jj] = (psi[ii, jj] - psi[ii - 1, jj]) / dz
-				else:
-					Br[ii, jj] = (psi[ii + 1, jj] - psi[ii - 1, jj]) / (2 * dz)
-				Br[ii,jj] = - Br[ii,jj] / R[ii,jj]
-		return Br, Bz
+class Coils:
+    """
+    Class for the representation of the external magnetic field coils
+
+    Args:
+            coilName (str): path to the file containing coil data
+
+    Return:
+            Jc (array): np.array of length Ncoils containting current density flowing into each coil
+    """
+
+    def __init__(self, coilName):
+        """
+        Initialise the main coil properties starting from a .txt file
+        """
+        CoilParam = np.loadtxt(coilName)
+        self.Ncoils = np.shape(CoilParam)[1]
+        self.Rc1 = CoilParam[0, :]
+        self.Zc1 = CoilParam[1, :]
+        self.Rc2 = CoilParam[2, :]
+        self.Zc2 = CoilParam[3, :]
+        self.Ic = CoilParam[4, :]
+        self.Jc = Coils.ComputeCurrents(self)
+
+    @classmethod
+    def from_keyboard(cls):
+        coilName = input("Insert coil file name:")
+        coilName = "/Users/michele/Desktop/LPDEquilibria/Coils/" + coilName
+        Coils.__init__(cls, coilName)
+        return cls
+
+    def ComputeCurrents(self):
+        """
+        Compute the coils current density, assuming that the coil is a square
+        """
+        Jc = np.zeros(self.Ncoils)
+        Jc = self.Ic / ((self.Rc2 - self.Rc1) * (self.Zc2 - self.Zc1))
+        return Jc
+
+
+class Equilibrium:
+    """
+    Class to represent the Equilibrium of the machine on a [r1, r2]x[z1, z2] grid
+
+    Args:
+            r1 (float): lower boundary of the computational domain in the r direction
+            r2 (float): upper boundary of the computational domain in the r direction
+            z1 (float): lower boundary of the computational domain in the z direction
+            z2 (float): upper boundary of the computational domain in the z direction
+            Nr (int): Number of points in the radial direction
+            Nz (int): Number of points in the axial direction
+            R (float): numpy NrxNz array
+            Z (float): numpy NrxNz array
+            psi (float): numpy NrxNz array containing the stream function
+            Br (float): numpy NrxNz array containing the r component of the magnetic field
+            Bz (float): numpy NrxNz array containing the z component of the magnetic fieldq
+
+    Return:
+            Eq (object)
+    """
+
+    def __init__(self, r1, r2, z1, z2, Nr, Nz, Nc=10):
+        self.__mu0 = 4 * np.pi * 1.0e-07
+        self.r1 = r1
+        self.r2 = r2
+        self.z1 = z1
+        self.z2 = z2
+        self.Nr = Nr
+        self.Nz = Nz
+        self.Nc = Nc
+        self.Coil = Coils.from_keyboard()
+        R, Z = Equilibrium.BuildGrid(self)
+        self.R = R
+        self.Z = Z
+        self.psi = Equilibrium.ComputePsi(self)
+        Br, Bz = Equilibrium.ComputeField(self)
+        self.Br = Br
+        self.Bz = Bz
+
+    def BuildGrid(self):
+        """
+        Construct cartesian grid in the (R, Z) plane necessary for the computation of the equilibrium
+        """
+        r1, r2, z1, z2, Nr, Nz = self.r1, self.r2, self.z1, self.z2, self.Nr, self.Nz
+        r = np.linspace(r1, r2, Nr)
+        z = np.linspace(z1, z2, Nz)
+        R, Z = np.meshgrid(r, z)
+        return R, Z
+
+    def BuildGridCoils(self, index):
+        """
+        Compute a cartesian grid on each of the (index) coil with a predefined (Nc=10) number of points
+        """
+        Rc1, Rc2, Zc1, Zc2, Nc = self.Coil.Rc1, self.Coil.Rc2, self.Coil.Zc1, self.Coil.Zc2, self.Nc
+        zc = np.linspace(Zc2[index], Zc1[index], Nc)
+        rc = np.linspace(Rc2[index], Rc1[index], Nc)
+        Rc, Zc = np.meshgrid(rc, zc)
+        return Rc, Zc, rc, zc
+
+    def ComputePsi(self):
+        """
+        Compute the poloidal flux function using the Green Function method of the Grad-Shafranov Equation
+        """
+        R, Z, Nr, Nz, Nc, Jc, Ncoil, mu0 = (
+            self.R,
+            self.Z,
+            self.Nr,
+            self.Nz,
+            self.Nc,
+            self.Coil.Jc,
+            self.Coil.Ncoils,
+            self.__mu0,
+        )
+        psi_coil = np.zeros((Nz, Nr, Ncoil))
+        for ll in range(0, Ncoil):
+            G = np.zeros((Nz, Nr, Nc, Nc))
+            Rc, Zc, rc, zc = Equilibrium.BuildGridCoils(self, ll)
+            for kk in range(0, Nc):
+                for mm in range(0, Nc):
+                    k2 = (4.0 * R * Rc[kk, mm]) / ((R + Rc[kk, mm]) ** 2 + (Z - Zc[kk, mm]) ** 2)
+                    k = np.sqrt(k2)
+                    K = ellipk(k2)
+                    E = ellipe(k2)
+                    G[:, :, kk, mm] = (
+                        Jc[ll]
+                        * ((mu0 / (2 * np.pi)) * np.sqrt(R * Rc[kk, mm]) / k)
+                        * ((2 - k2) * K - 2 * E)
+                    )
+            psi_coil[:, :, ll] = np.trapz(np.trapz(G, zc), rc)
+        psi = psi_coil.sum(axis=2)
+        return psi
+
+    def ComputeField(self):
+        """
+        Function for the computation of the radial and axial magnetic field components
+        """
+        Nr, Nz, r2, r1, z2, z1, psi, R = (
+            self.Nr,
+            self.Nz,
+            self.r2,
+            self.r1,
+            self.z2,
+            self.z1,
+            self.psi,
+            self.R,
+        )
+        Br = np.zeros((Nz, Nr))
+        Bz = np.zeros((Nz, Nr))
+        dr = (r2 - r1) / (Nr - 1)
+        dz = (z2 - z1) / (Nz - 1)
+        # Compute the axial magnetic field
+        for ii in range(0, Nz):
+            for jj in range(0, Nr):
+                if jj == 0:
+                    Bz[ii, jj] = 2 * (psi[ii, jj + 1] - psi[ii, jj]) / (dr * dr)
+                elif jj == Nr - 1:
+                    Bz[ii, jj] = (psi[ii, jj] - psi[ii, jj - 1]) / dr
+                    Bz[ii, jj] = Bz[ii, jj] / R[ii, jj]
+                else:
+                    Bz[ii, jj] = (psi[ii, jj + 1] - psi[ii, jj - 1]) / (2 * dr)
+                    Bz[ii, jj] = Bz[ii, jj] / R[ii, jj]
+        # Compute the radial magnetic field
+        for ii in range(0, Nz):
+            for jj in range(0, Nr):
+                if ii == 0:
+                    Br[ii, jj] = (psi[ii + 1, jj] - psi[ii, jj]) / dz
+                elif ii == Nz - 1:
+                    Br[ii, jj] = (psi[ii, jj] - psi[ii - 1, jj]) / dz
+                else:
+                    Br[ii, jj] = (psi[ii + 1, jj] - psi[ii - 1, jj]) / (2 * dz)
+                Br[ii, jj] = -Br[ii, jj] / R[ii, jj]
+        return Br, Bz
 
 
 class Mesh:
-	"""
-	Class for the definition and construction of a field-aligned structured Mesh
-	
-	Input:
-		Eq (objtect): equilibrium object defining the magnetic equilibrium 
-		m (int): number of point in the radial direction
-		n (int): number of point in the axial direction 
-		Rlim (float): location in the r direction of the limiting surface
-		
-	Return:
-		Mesh (object)
-	""" 
-	def __init__(self, Eq, m, n, Rlim):
-		self.Eq = Eq
-		self.m = m
-		self.n = n
-		self.__Ncont = 100
-		self.__LowerPsiValue = 1.0E-08
-		self.__Dim = 24
-		self.Rlim = Rlim
-		PsiLim = Mesh.ComputeLastPsi(self)
-		Mesh.PsiLim = PsiLim
-		self.Mesh = Mesh.ComputeGrid(self)
-	def ComputeLastPsi(self):
-		"""
-		Function for the computation of the last magnetic flux surface
-		"""
-		psi, R, Z, LowerPsiValue, Ncont, Rlim = self.Eq.psi, self.Eq.R, self.Eq.Z, self.__LowerPsiValue,  self.__Ncont, self.Rlim
-		ContourLevels = np.linspace(LowerPsiValue, psi.max(), Ncont)
-		Cnt = plt.contour(R, Z,psi, ContourLevels)
-		lines = []
-		for it in range(0, Ncont):
-			for line in Cnt.collections[it].get_paths():
-				lines.append(line.vertices)
-			r = np.array(lines[it])[:, 0].max() - Rlim
-			if r >= 0: 
-				print('Found LCFS at: ', ContourLevels[it - 1])                
-				break                
-		return ContourLevels[it - 1]
-	def InterpolatePsi(self, zP, rP, zQuery, ContourLevels):
-		""" 
-		Function for the interpolation of the psi function
-		"""
-		psi = self.Eq.psi
-		for ii in range(0, ContourLevels.size):
-			Cnt = np.array(plt.contour(rP, zP, psi, [ContourLevels[ii]]).allsegs)
-			plt.ioff()
-			Shape = Cnt.shape
-			r = Cnt.reshape(Shape[2], 2)[:, 0]
-			z = Cnt.reshape(Shape[2], 2)[:, 1]
-			InterpFunc = scipy.interpolate.interp1d(z, r, fill_value="extrapolate")
-			if ii == 0:
-				InterpPsi = InterpFunc(zQuery).reshape(1, zQuery.size)
-			else:
-				InterpPsi = np.append(InterpPsi, InterpFunc(zQuery).reshape(1, zQuery.size), axis=0)
-		return InterpPsi.T
-	def InterpolateField(self, rQuery, MESH):
-		psi, Bz, R, Z, n, m = self.Eq.psi,self.Eq.Bz, self.Eq.R, self.Eq.Z, self.n, self.m
-		zQuery = MESH[:, 3]
-		BzC = np.zeros(n * (m + 2))  
-		InterpFunc = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], Bz)        
-		for ii in range(0, zQuery.size):
-			BzC[ii] = InterpFunc(zQuery[ii], rQuery[ii])
-		return BzC       
-	def ComputeGrid(self):
-		LowerPsiValue, PsiLim, m, n, Z, R, z2 = self.__LowerPsiValue, self.PsiLim, self.m, self.n, self.Eq.Z, self.Eq.R, self.Eq.z2
-		ContourLevels = np.linspace(np.sqrt(LowerPsiValue), np.sqrt(PsiLim), m) ** 2 
-		zValues = Z[:, 0]
-		rValues = R[0, :]
-		alpha = 1.8
-		overshoot = 1.0E-05
-		func = lambda x : z2 * ( ( np.tanh(-x)) / (np.tanh(alpha)) * (1+overshoot)) / (1 + overshoot)
-		IndexFunc = np.linspace(-alpha, alpha, 2 * n + 1)
-		zQuery = func(IndexFunc)
-		InterpPsi = Mesh.InterpolatePsi(self, zValues, rValues, zQuery, ContourLevels)
-		crxT = zQuery[0 : zQuery.size - 1 : 2]    
-		crxB = zQuery[2 : zQuery.size : 2]
-		cryLT = InterpPsi[0 : InterpPsi.shape[0] - 1: 2, 0 : InterpPsi.shape[1] - 1].T.reshape(1, n * (m - 1))
-		cryRT = InterpPsi[0 : InterpPsi.shape[0] - 1: 2, 1 : InterpPsi.shape[1]].T.reshape(1, n * (m - 1))
-		cryLB = InterpPsi[2 : InterpPsi.shape[0] : 2, 0 : InterpPsi.shape[1] - 1].T.reshape(1, n * (m - 1))
-		cryRB = InterpPsi[2 : InterpPsi.shape[0] : 2, 1 : InterpPsi.shape[1]].T.reshape(1, n * (m - 1))
-		cryBottomGuard = np.zeros((1, n))
-		cryUpperGuard = Mesh.InterpolatePsi(self, zValues, rValues, zQuery, np.array([1.0E-12]))
-		cryUpperGuardLT = cryUpperGuard[0 : cryUpperGuard.size - 1: 2]
-		cryUpperGuardLB = cryUpperGuard[2 : cryUpperGuard.size : 2]       
-		cryLT = np.append(np.append(cryBottomGuard, cryUpperGuardLT), cryLT)
-		cryLB = np.append(np.append(cryBottomGuard, cryUpperGuardLB), cryLB)
-		cryRT = np.append(np.append(cryUpperGuardLT, cryLT[2 * n: 3 * n]), cryRT)
-		cryRB = np.append(np.append(cryUpperGuardLB, cryLB[2 * n: 3 * n]), cryRB) 
-		cryLB = np.append(cryLB, cryRB[cryRB.size - n: cryRB.size])
-		cryLT = np.append(cryLT, cryRT[cryRB.size - n: cryRB.size])
-		cryRT = np.append(cryRT, cryRT[cryRB.size - n: cryRB.size] + 1.0E-05)
-		cryRB = np.append(cryRB, cryRB[cryRB.size - n: cryRB.size] + 1.0E-05)
-		cryC = (cryLT + cryRB) / 2 
-		crxC = (crxT + crxB) / 2      
-		MESH = np.empty((n * (m + 2), 14))
-		MESH[:, 2] = cryC
-		MESH[:, 3] = np.matlib.repmat(crxC, 1, m + 2)
-		MESH[:, 4] = cryLT
-		MESH[:, 5] = np.matlib.repmat(crxT, 1, m + 2)  
-		MESH[:, 6] = cryLB
-		MESH[:, 7] = np.matlib.repmat(crxB, 1, m + 2)
-		MESH[:, 8] = cryRT
-		MESH[:, 9] = np.matlib.repmat(crxT, 1, m + 2)
-		MESH[:, 10] = cryRB
-		MESH[:, 11] = np.matlib.repmat(crxB, 1, m + 2)
-		MESH[:, 0] = np.matlib.repmat(np.array([range(0, n)]), 1, m + 2)
-		MESH[:, 1] = np.matlib.repeat(np.array([range(0, m + 2)]), n)
-		BzC = Mesh.InterpolateField(self, cryC, MESH)
-		MESH[:, 12] = BzC.reshape(n * (m  + 2))
-		MESH[:, 13] = 0
-		return MESH 
-	def PlotMesh(self):
-		Mesh = self.Mesh
-		it = 0       
-		Mesh = np.delete(Mesh, (1), axis = 1)
-		Mesh = np.delete(Mesh, (0), axis = 1)
-		Shape = Mesh.shape
-		A = np.zeros(Shape[0] * (Shape[1] - 2))        
-		for ii in range(0, Shape[0]): 
-			for jj in range(0, Shape[1] - 2):
-				A[it] = Mesh[ii, jj]
-				it = it + 1
-		x = A[0 : A.size : 2]
-		y = A[1 : A.size : 2]       
-		Points = self.n * 5           
-		fig, ax = plt.subplots()
-		for ii in range(0, self.m + 3):
-			ax.plot(x[ii * self.n * 5 + 1 : Points], y[ii * self.n * 5 + 1 : Points], 'black', linewidth = 0.5)
-			Points = Points + self.n * 5
-		ax.set_aspect(aspect=0.3)
-		ax.set_xlabel('R [m]')
-		ax.set_ylabel('Z [m]')
-		plt.show()
-	def WriteMesh(self): 
-		Mesh = self.Mesh
-		Name = input('Insert Mesh name: ') + '.ASCII'    
-		pathName = 'meshes/' 
-		np.savetxt(pathName + Name, Mesh, '%.8E')
-		print('Saved Mesh in file: ' + Name)        
+    """
+    Class for the definition and construction of a field-aligned structured Mesh
 
-class PlotEquilibrium: 
-	""" 
-	Class for plotting the Equilibrium object
-	"""
-	def __init__(self, Eq, Ncont = 100, Dim = 24):
-		self.Equ = Eq
-		self.Ncont = Ncont
-		self.Dim = Dim
-	def PlotPsiContour(self):
-		"""
-		Contour plot of psi
-		"""
-		R, Z, psi, Ncont = self.Equ.R, self.Equ.Z, self.Equ.psi, self.Ncont
-		fig, ax = plt.subplots()
-		cnt = ax.contour(R, Z, psi, Ncont, cmap=matplotlib.cm.RdGy, vmin=abs(self.Equ.psi).min(), vmax=abs(self.Equ.psi).max())
-		ax.set_xlabel('R [m]')
-		ax.set_ylabel('Z [m]')
-		cb = fig.colorbar(cnt, ax=ax)
-		# plt.show()
-	def PlotBContour(self):
-		"""
-		Contour plot of B
-		""" 
-		R, Z, Br, Bz, Ncont = self.Equ.R, self.Equ.Z, self.Equ.Br, self.Equ.Bz, self.Ncont
-		B = np.sqrt(self.Equ.Br ** 2 + self.Equ.Bz ** 2)
-		fig, ax = plt.subplots()
-		cnt = ax.contourf(R, Z, B, Ncont, cmap=matplotlib.cm.RdGy, vmin=abs(B).min(), vmax=abs(B).max())
-		ax.set_xlabel('R [m]')
-		ax.set_ylabel('Z [m]')
-		cb = fig.colorbar(cnt, ax=ax)
-		plt.show()
-	def PlotPsiBContour(self): 
-		"""
-		Plot psi and B contour on the same figure
-		"""
-		R, Z, Br, Bz, psi, Ncont = self.Equ.R, self.Equ.Z, self.Equ.Br, self.Equ.Bz, self.Equ.psi, self.Ncont
-		B = np.sqrt(self.Equ.Br ** 2 + self.Equ.Bz ** 2)
-		fig, ax = plt.subplots(nrows = 2, ncols = 1)
-		cntPsi = ax[0].contour(R[0, :], Z[:, 0], psi, Ncont, cmap=matplotlib.cm.RdGy,vmin=abs(psi).min(), vmax=abs(psi).max())
-		cb = fig.colorbar(cntPsi, ax = ax[0])
-		ax[0].set_xlabel('R [m]')
-		ax[0].set_ylabel('Z [m]')
-		cntB = ax[1].contourf(R, Z, B, Ncont, cmap=matplotlib.cm.RdGy,vmin=abs(B).min(), vmax=abs(B).max())
-		cb = fig.colorbar(cntB, ax = ax[1])
-		ax[1].set_xlabel('R [m]')
-		ax[1].set_ylabel('Z [m]')
-		plt.show()
+    Input:
+            Eq (objtect): equilibrium object defining the magnetic equilibrium
+            m (int): number of point in the radial direction
+            n (int): number of point in the axial direction
+            Rlim (float): location in the r direction of the limiting surface
+
+    Return:
+            Mesh (object)
+    """
+
+    def __init__(self, Eq, m, n, Rlim):
+        self.Eq = Eq
+        self.m = m
+        self.n = n
+        self.__Ncont = 100
+        self.__LowerPsiValue = 1.0e-08
+        self.__Dim = 24
+        self.Rlim = Rlim
+        PsiLim = Mesh.ComputeLastPsi(self)
+        Mesh.PsiLim = PsiLim
+        self.Mesh = Mesh.ComputeGrid(self)
+
+    def ComputeLastPsi(self):
+        """
+        Function for the computation of the last magnetic flux surface
+        """
+        psi, R, Z, LowerPsiValue, Ncont, Rlim = (
+            self.Eq.psi,
+            self.Eq.R,
+            self.Eq.Z,
+            self.__LowerPsiValue,
+            self.__Ncont,
+            self.Rlim,
+        )
+        ContourLevels = np.linspace(LowerPsiValue, psi.max(), Ncont)
+        Cnt = plt.contour(R, Z, psi, ContourLevels)
+        lines = []
+        for it in range(0, Ncont):
+            for line in Cnt.collections[it].get_paths():
+                lines.append(line.vertices)
+            r = np.array(lines[it])[:, 0].max() - Rlim
+            if r >= 0:
+                print("Found LCFS at: ", ContourLevels[it - 1])
+                break
+        return ContourLevels[it - 1]
+
+    def InterpolatePsi(self, zP, rP, zQuery, ContourLevels):
+        """
+        Function for the interpolation of the psi function
+        """
+        psi = self.Eq.psi
+        for ii in range(0, ContourLevels.size):
+            Cnt = np.array(plt.contour(rP, zP, psi, [ContourLevels[ii]]).allsegs)
+            plt.ioff()
+            Shape = Cnt.shape
+            r = Cnt.reshape(Shape[2], 2)[:, 0]
+            z = Cnt.reshape(Shape[2], 2)[:, 1]
+            InterpFunc = scipy.interpolate.interp1d(z, r, fill_value="extrapolate")
+            if ii == 0:
+                InterpPsi = InterpFunc(zQuery).reshape(1, zQuery.size)
+            else:
+                InterpPsi = np.append(InterpPsi, InterpFunc(zQuery).reshape(1, zQuery.size), axis=0)
+        return InterpPsi.T
+
+    def InterpolateField(self, rQuery, MESH):
+        psi, Bz, R, Z, n, m = self.Eq.psi, self.Eq.Bz, self.Eq.R, self.Eq.Z, self.n, self.m
+        zQuery = MESH[:, 3]
+        BzC = np.zeros(n * (m + 2))
+        InterpFunc = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], Bz)
+        for ii in range(0, zQuery.size):
+            BzC[ii] = InterpFunc(zQuery[ii], rQuery[ii])
+        return BzC
+
+    def ComputeGrid(self):
+        LowerPsiValue, PsiLim, m, n, Z, R, z2 = (
+            self.__LowerPsiValue,
+            self.PsiLim,
+            self.m,
+            self.n,
+            self.Eq.Z,
+            self.Eq.R,
+            self.Eq.z2,
+        )
+        ContourLevels = np.linspace(np.sqrt(LowerPsiValue), np.sqrt(PsiLim), m) ** 2
+        zValues = Z[:, 0]
+        rValues = R[0, :]
+        alpha = 1.8
+        overshoot = 1.0e-05
+        func = lambda x: z2 * ((np.tanh(-x)) / (np.tanh(alpha)) * (1 + overshoot)) / (1 + overshoot)
+        IndexFunc = np.linspace(-alpha, alpha, 2 * n + 1)
+        zQuery = func(IndexFunc)
+        InterpPsi = Mesh.InterpolatePsi(self, zValues, rValues, zQuery, ContourLevels)
+        crxT = zQuery[0 : zQuery.size - 1 : 2]
+        crxB = zQuery[2 : zQuery.size : 2]
+        cryLT = InterpPsi[0 : InterpPsi.shape[0] - 1 : 2, 0 : InterpPsi.shape[1] - 1].T.reshape(
+            1, n * (m - 1)
+        )
+        cryRT = InterpPsi[0 : InterpPsi.shape[0] - 1 : 2, 1 : InterpPsi.shape[1]].T.reshape(
+            1, n * (m - 1)
+        )
+        cryLB = InterpPsi[2 : InterpPsi.shape[0] : 2, 0 : InterpPsi.shape[1] - 1].T.reshape(
+            1, n * (m - 1)
+        )
+        cryRB = InterpPsi[2 : InterpPsi.shape[0] : 2, 1 : InterpPsi.shape[1]].T.reshape(
+            1, n * (m - 1)
+        )
+        cryBottomGuard = np.zeros((1, n))
+        cryUpperGuard = Mesh.InterpolatePsi(self, zValues, rValues, zQuery, np.array([1.0e-12]))
+        cryUpperGuardLT = cryUpperGuard[0 : cryUpperGuard.size - 1 : 2]
+        cryUpperGuardLB = cryUpperGuard[2 : cryUpperGuard.size : 2]
+        cryLT = np.append(np.append(cryBottomGuard, cryUpperGuardLT), cryLT)
+        cryLB = np.append(np.append(cryBottomGuard, cryUpperGuardLB), cryLB)
+        cryRT = np.append(np.append(cryUpperGuardLT, cryLT[2 * n : 3 * n]), cryRT)
+        cryRB = np.append(np.append(cryUpperGuardLB, cryLB[2 * n : 3 * n]), cryRB)
+        cryLB = np.append(cryLB, cryRB[cryRB.size - n : cryRB.size])
+        cryLT = np.append(cryLT, cryRT[cryRB.size - n : cryRB.size])
+        cryRT = np.append(cryRT, cryRT[cryRB.size - n : cryRB.size] + 1.0e-05)
+        cryRB = np.append(cryRB, cryRB[cryRB.size - n : cryRB.size] + 1.0e-05)
+        cryC = (cryLT + cryRB) / 2
+        crxC = (crxT + crxB) / 2
+        MESH = np.empty((n * (m + 2), 14))
+        MESH[:, 2] = cryC
+        MESH[:, 3] = np.matlib.repmat(crxC, 1, m + 2)
+        MESH[:, 4] = cryLT
+        MESH[:, 5] = np.matlib.repmat(crxT, 1, m + 2)
+        MESH[:, 6] = cryLB
+        MESH[:, 7] = np.matlib.repmat(crxB, 1, m + 2)
+        MESH[:, 8] = cryRT
+        MESH[:, 9] = np.matlib.repmat(crxT, 1, m + 2)
+        MESH[:, 10] = cryRB
+        MESH[:, 11] = np.matlib.repmat(crxB, 1, m + 2)
+        MESH[:, 0] = np.matlib.repmat(np.array([range(0, n)]), 1, m + 2)
+        MESH[:, 1] = np.matlib.repeat(np.array([range(0, m + 2)]), n)
+        BzC = Mesh.InterpolateField(self, cryC, MESH)
+        MESH[:, 12] = BzC.reshape(n * (m + 2))
+        MESH[:, 13] = 0
+        return MESH
+
+    def PlotMesh(self):
+        Mesh = self.Mesh
+        it = 0
+        Mesh = np.delete(Mesh, (1), axis=1)
+        Mesh = np.delete(Mesh, (0), axis=1)
+        Shape = Mesh.shape
+        A = np.zeros(Shape[0] * (Shape[1] - 2))
+        for ii in range(0, Shape[0]):
+            for jj in range(0, Shape[1] - 2):
+                A[it] = Mesh[ii, jj]
+                it = it + 1
+        x = A[0 : A.size : 2]
+        y = A[1 : A.size : 2]
+        Points = self.n * 5
+        fig, ax = plt.subplots()
+        for ii in range(0, self.m + 3):
+            ax.plot(
+                x[ii * self.n * 5 + 1 : Points],
+                y[ii * self.n * 5 + 1 : Points],
+                "black",
+                linewidth=0.5,
+            )
+            Points = Points + self.n * 5
+        ax.set_aspect(aspect=0.3)
+        ax.set_xlabel("R [m]")
+        ax.set_ylabel("Z [m]")
+        plt.show()
+
+    def WriteMesh(self):
+        Mesh = self.Mesh
+        Name = input("Insert Mesh name: ") + ".ASCII"
+        pathName = "meshes/"
+        np.savetxt(pathName + Name, Mesh, "%.8E")
+        print("Saved Mesh in file: " + Name)
+
+
+class PlotEquilibrium:
+    """
+    Class for plotting the Equilibrium object
+    """
+
+    def __init__(self, Eq, Ncont=100, Dim=24):
+        self.Equ = Eq
+        self.Ncont = Ncont
+        self.Dim = Dim
+
+    def PlotPsiContour(self):
+        """
+        Contour plot of psi
+        """
+        R, Z, psi, Ncont = self.Equ.R, self.Equ.Z, self.Equ.psi, self.Ncont
+        fig, ax = plt.subplots()
+        cnt = ax.contour(
+            R,
+            Z,
+            psi,
+            Ncont,
+            cmap=matplotlib.cm.RdGy,
+            vmin=abs(self.Equ.psi).min(),
+            vmax=abs(self.Equ.psi).max(),
+        )
+        ax.set_xlabel("R [m]")
+        ax.set_ylabel("Z [m]")
+        cb = fig.colorbar(cnt, ax=ax)
+        # plt.show()
+
+    def PlotBContour(self):
+        """
+        Contour plot of B
+        """
+        R, Z, Br, Bz, Ncont = self.Equ.R, self.Equ.Z, self.Equ.Br, self.Equ.Bz, self.Ncont
+        B = np.sqrt(self.Equ.Br**2 + self.Equ.Bz**2)
+        fig, ax = plt.subplots()
+        cnt = ax.contourf(
+            R, Z, B, Ncont, cmap=matplotlib.cm.RdGy, vmin=abs(B).min(), vmax=abs(B).max()
+        )
+        ax.set_xlabel("R [m]")
+        ax.set_ylabel("Z [m]")
+        cb = fig.colorbar(cnt, ax=ax)
+        plt.show()
+
+    def PlotPsiBContour(self):
+        """
+        Plot psi and B contour on the same figure
+        """
+        R, Z, Br, Bz, psi, Ncont = (
+            self.Equ.R,
+            self.Equ.Z,
+            self.Equ.Br,
+            self.Equ.Bz,
+            self.Equ.psi,
+            self.Ncont,
+        )
+        B = np.sqrt(self.Equ.Br**2 + self.Equ.Bz**2)
+        fig, ax = plt.subplots(nrows=2, ncols=1)
+        cntPsi = ax[0].contour(
+            R[0, :],
+            Z[:, 0],
+            psi,
+            Ncont,
+            cmap=matplotlib.cm.RdGy,
+            vmin=abs(psi).min(),
+            vmax=abs(psi).max(),
+        )
+        cb = fig.colorbar(cntPsi, ax=ax[0])
+        ax[0].set_xlabel("R [m]")
+        ax[0].set_ylabel("Z [m]")
+        cntB = ax[1].contourf(
+            R, Z, B, Ncont, cmap=matplotlib.cm.RdGy, vmin=abs(B).min(), vmax=abs(B).max()
+        )
+        cb = fig.colorbar(cntB, ax=ax[1])
+        ax[1].set_xlabel("R [m]")
+        ax[1].set_ylabel("Z [m]")
+        plt.show()
+
 
 class Resonances:
-	"""
-	Class for the computation of the various resonances in the machine
-	
-	Input:
-	
-		OmegaInj (float): frequency of the injected electromagnetic wave
-		Eq (object): equilibrium object 
-		Mesh (object): mesh object
-		neFit (function): function specifying the fitting expression to be used for the electron density
-	
-	"""
-	def __init__(self, OmegaInj, Eq, Mesh, neFit): 
-		self.OmegaInj = OmegaInj
-		self.Eq = Eq
-		self.Mesh = Mesh
-		self.__e = 1.6e-19
-		self.__me = 9.11e-31
-		self.__mi = 2 * 1.672e-27
-		self.neFit = neFit
-		self.OmegaCE, self.OmegaUH, self.OmegaLH, self.OmegaPE = Resonances.ComputeResonances(self)
-		self.OmegaC1, self.OmegaC2 = Resonances.ComputeCutOff(self)
-		self.ZResPosition = Resonances.LocateAxial(self)
-	def ComputeResonances(self):
-		Br, Bz, e, me, mi, neFit, Eq = self.Eq.Br, self.Eq.Bz, self.__e, self.__me, self.__mi, self.neFit, self.Eq
-		B = np.sqrt(Br ** 2 + Bz ** 2)
-		OmegaCE = e * B / (2 * np.pi * me)
-		OmegaCI = e * B / (2 * np.pi * mi)  
-		#OmegaPE = 8.98 * np.sqrt(neFit(Eq.R, Eq.Z))
-		OmegaPE = 8.98 * np.sqrt(interpolate.splev(Eq.R, neFit))
-		plt.contourf(Eq.R[0, :], Eq.Z[:, 0], interpolate.splev(Eq.R, neFit))
-		plt.colorbar()
-		plt.show()
-		OmegaPI = 1 / (2 * np.pi) * np.sqrt(me / mi) * OmegaPE
-		OmegaUH = np.sqrt(OmegaPE ** 2 + OmegaCE ** 2)
-		OmegaLH = np.sqrt(OmegaCE * OmegaCI * (1 + OmegaCI ** 2 / OmegaPI ** 2) / (1 + OmegaCE ** 2 / OmegaPE ** 2))
-		return OmegaCE, OmegaUH, OmegaLH, OmegaPE
-	def ComputeCutOff(self):
-		OmegaCE, OmegaPE = self.OmegaCE, self.OmegaPE
-		OmegaC1 = 0.5 * (np.sqrt(4. * OmegaPE ** 2 + OmegaCE ** 2) - OmegaCE)
-		OmegaC2 = 0.5 * (np.sqrt(4. * OmegaPE ** 2 + OmegaCE ** 2) + OmegaCE)
-		return OmegaC1, OmegaC2  
-	def LocateAxial(self): 
-		"""Method for the computation of the axial location of the resonace"""
-		OmegaInj, Br, Bz, psi, R, Z, e, me, mi, OmegaCE = self.OmegaInj, self.Eq.Br, self.Eq.Bz, self.Eq.psi, self.Eq.R, self.Eq.Z, self.__e, self.__me, self.__mi, self.OmegaCE
-		cs = plt.contour(R[0, :], Z[:, 0], OmegaCE, [OmegaInj])
-		lines = []
-		for line in cs.collections[0].get_paths():
-			lines.append(line.vertices)
-		zpos = np.empty(len(lines))            
-		for ii in range(0, len(lines)):
-			zpos[ii] = np.array(lines[ii]) [:, 1].min()           
-		return zpos
-	def PlotResonances(self): 
-		"""Method for plotting of the resonances"""
-		OmegaInj, OmegaCE, OmegaUH, OmegaLH, R, Z = self.OmegaInj, self.OmegaCE, self.OmegaUH, self.OmegaLH, self.Eq.R, self.Eq.Z
-		fig, ax = plt.subplots(nrows = 1, ncols = 3, figsize = (10, 10))
-		ax[0].contour(R[0, :], Z[:, 0], OmegaCE, [OmegaInj])
-		ax[0].set_title('$\Omega_{CE}$')  
-		ax[0].set_xlabel('R [m]')
-		ax[0].set_ylabel('Z [m]') 
-		ax[1].contour(R[0, :], Z[:, 0], OmegaUH, [OmegaInj])
-		ax[1].set_title('$\Omega_{UH}$')
-		ax[1].set_xlabel('R [m]')
-		ax[1].set_ylabel('Z [m]')
-		ax[2].contour(R[0, :], Z[:, 0], OmegaLH, [OmegaInj])
-		ax[2].set_title('$\Omega_{LH}$')
-		ax[2].set_xlabel('R [m]')
-		ax[2].set_ylabel('Z [m]')
-		plt.show()
-		plt.contourf(R[0, :], Z[:, 0], OmegaUH)
-		plt.colorbar()
-		fig.tight_layout()
-	def PlotCutOff(self): 
-		"""Method for plotting of the cutoffs"""
-		OmegaInj, OmegaC1, OmegaC2, R, Z= self.OmegaInj, self.OmegaC1, self.OmegaC2, self.Eq.R, self.Eq.Z
-		fig, ax = plt.subplots(nrows = 1, ncols = 2, figsize = (10, 10))
-		ax[0].contour(R[0, :], Z[:, 0], OmegaC1, [OmegaInj])
-		ax[0].set_title('$\Omega_{C1}$')  
-		ax[0].set_xlabel('R [m]')
-		ax[0].set_ylabel('Z [m]') 
-		ax[1].contour(R[0, :], Z[:, 0], OmegaC2, [OmegaInj])
-		ax[1].set_title('$\Omega_{C2}$')
-		ax[1].set_xlabel('R [m]')
-		ax[1].set_ylabel('Z [m]')
-		fig.tight_layout()
-		plt.show()
-		plt.contourf(R[0, :], Z[:, 0], OmegaC2)
-		plt.colorbar()
-	def PlotResonancesMesh(self): 
-		"""Method for plotting of the resonances on the physical mesh"""       
-		OmegaCE, OmegaUH, OmegaLH, R, Z, Grid, n, m, OmegaInj = self.OmegaCE, self.OmegaUH, self.OmegaLH, self.Eq.R, self.Eq.Z, self.Mesh.Mesh, self.Mesh.n, self.Mesh.m, self.OmegaInj
-		OmegaCEInterp = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], OmegaCE)  
-		OmegaUHInterp = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], OmegaUH) 
-		OmegaLHInterp = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], OmegaLH)
-		Rc, Zc = Grid[:, 2], Grid[:, 3]
-		OmegaCEGrid = np.zeros(n * (m + 2))
-		OmegaUHGrid = np.zeros(n * (m + 2))
-		OmegaLHGrid = np.zeros(n * (m + 2))
-		for ii in range(0, Rc.size):
-			OmegaCEGrid[ii] = OmegaCEInterp(Zc[ii], Rc[ii])
-			OmegaUHGrid[ii] = OmegaUHInterp(Zc[ii], Rc[ii])    
-			OmegaLHGrid[ii] = OmegaLHInterp(Zc[ii], Rc[ii])
-		OmegaCEGrid = OmegaCEGrid.reshape(m + 2, n)
-		OmegaUHGrid = OmegaUHGrid.reshape(m + 2, n)
-		OmegaLHGrid = OmegaLHGrid.reshape(m + 2, n)
-		it = 0       
-		Grid = np.delete(Grid, (1), axis = 1)
-		Grid = np.delete(Grid, (0), axis = 1)
-		Shape = Grid.shape
-		A = np.zeros(Shape[0] * (Shape[1] - 2))        
-		for ii in range(0, Shape[0]): 
-			for jj in range(0, Shape[1] - 2):
-				A[it] = Grid[ii, jj]
-				it = it + 1
-		x = A[0 : A.size : 2]
-		y = A[1 : A.size : 2]       
-		Points = n * 5  
-		Rc = Rc.reshape(m + 2, n)
-		Zc = Zc.reshape(m + 2, n)   
-		fig, ax = plt.subplots(nrows = 1, ncols = 3, figsize = (10, 10))
-		ax[0].contour(Rc, Zc, OmegaCEGrid, [OmegaInj]) 
-		ax[0].set_title('$\Omega_{CE}$')  
-		ax[0].set_xlabel('R [m]')
-		ax[0].set_ylabel('Z [m]')         
-		for ii in range(0, m + 3):
-			ax[0].plot(x[ii * n * 5 + 1 : Points], y[ii * n * 5 + 1 : Points], 'black', linewidth = 0.5)
-			Points = Points + n * 5
-		Points = n * 5  
-		ax[1].contour(Rc, Zc, OmegaUHGrid, [OmegaInj]) 
-		ax[1].set_title('$\Omega_{UH}$')  
-		ax[1].set_xlabel('R [m]')
-		ax[1].set_ylabel('Z [m]')
-		for ii in range(0, m + 3):
-			ax[1].plot(x[ii * n * 5 + 1 : Points], y[ii * n * 5 + 1 : Points], 'black', linewidth = 0.5)
-			Points = Points + n * 5
-		Points = n * 5  
-		ax[2].contour(Rc, Zc, OmegaLHGrid, [OmegaInj]) 
-		ax[2].set_title('$\Omega_{LH}$')  
-		ax[2].set_xlabel('R [m]')
-		ax[2].set_ylabel('Z [m]')
-		for ii in range(0, m + 3):
-			ax[2].plot(x[ii * n * 5 + 1 : Points], y[ii * n * 5 + 1 : Points], 'black', linewidth = 0.5)
-			Points = Points + n * 5
-		Points = n * 5  
-		plt.show()
-		fig.tight_layout()
+    """
+    Class for the computation of the various resonances in the machine
+
+    Input:
+
+            OmegaInj (float): frequency of the injected electromagnetic wave
+            Eq (object): equilibrium object
+            Mesh (object): mesh object
+            neFit (function): function specifying the fitting expression to be used for the electron density
+
+    """
+
+    def __init__(self, OmegaInj, Eq, Mesh, neFit):
+        self.OmegaInj = OmegaInj
+        self.Eq = Eq
+        self.Mesh = Mesh
+        self.__e = 1.6e-19
+        self.__me = 9.11e-31
+        self.__mi = 2 * 1.672e-27
+        self.neFit = neFit
+        self.OmegaCE, self.OmegaUH, self.OmegaLH, self.OmegaPE = Resonances.ComputeResonances(self)
+        self.OmegaC1, self.OmegaC2 = Resonances.ComputeCutOff(self)
+        self.ZResPosition = Resonances.LocateAxial(self)
+
+    def ComputeResonances(self):
+        Br, Bz, e, me, mi, neFit, Eq = (
+            self.Eq.Br,
+            self.Eq.Bz,
+            self.__e,
+            self.__me,
+            self.__mi,
+            self.neFit,
+            self.Eq,
+        )
+        B = np.sqrt(Br**2 + Bz**2)
+        OmegaCE = e * B / (2 * np.pi * me)
+        OmegaCI = e * B / (2 * np.pi * mi)
+        # OmegaPE = 8.98 * np.sqrt(neFit(Eq.R, Eq.Z))
+        OmegaPE = 8.98 * np.sqrt(interpolate.splev(Eq.R, neFit))
+        plt.contourf(Eq.R[0, :], Eq.Z[:, 0], interpolate.splev(Eq.R, neFit))
+        plt.colorbar()
+        plt.show()
+        OmegaPI = 1 / (2 * np.pi) * np.sqrt(me / mi) * OmegaPE
+        OmegaUH = np.sqrt(OmegaPE**2 + OmegaCE**2)
+        OmegaLH = np.sqrt(
+            OmegaCE * OmegaCI * (1 + OmegaCI**2 / OmegaPI**2) / (1 + OmegaCE**2 / OmegaPE**2)
+        )
+        return OmegaCE, OmegaUH, OmegaLH, OmegaPE
+
+    def ComputeCutOff(self):
+        OmegaCE, OmegaPE = self.OmegaCE, self.OmegaPE
+        OmegaC1 = 0.5 * (np.sqrt(4.0 * OmegaPE**2 + OmegaCE**2) - OmegaCE)
+        OmegaC2 = 0.5 * (np.sqrt(4.0 * OmegaPE**2 + OmegaCE**2) + OmegaCE)
+        return OmegaC1, OmegaC2
+
+    def LocateAxial(self):
+        """Method for the computation of the axial location of the resonace"""
+        OmegaInj, Br, Bz, psi, R, Z, e, me, mi, OmegaCE = (
+            self.OmegaInj,
+            self.Eq.Br,
+            self.Eq.Bz,
+            self.Eq.psi,
+            self.Eq.R,
+            self.Eq.Z,
+            self.__e,
+            self.__me,
+            self.__mi,
+            self.OmegaCE,
+        )
+        cs = plt.contour(R[0, :], Z[:, 0], OmegaCE, [OmegaInj])
+        lines = []
+        for line in cs.collections[0].get_paths():
+            lines.append(line.vertices)
+        zpos = np.empty(len(lines))
+        for ii in range(0, len(lines)):
+            zpos[ii] = np.array(lines[ii])[:, 1].min()
+        return zpos
+
+    def PlotResonances(self):
+        """Method for plotting of the resonances"""
+        OmegaInj, OmegaCE, OmegaUH, OmegaLH, R, Z = (
+            self.OmegaInj,
+            self.OmegaCE,
+            self.OmegaUH,
+            self.OmegaLH,
+            self.Eq.R,
+            self.Eq.Z,
+        )
+        fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(10, 10))
+        ax[0].contour(R[0, :], Z[:, 0], OmegaCE, [OmegaInj])
+        ax[0].set_title("$\Omega_{CE}$")
+        ax[0].set_xlabel("R [m]")
+        ax[0].set_ylabel("Z [m]")
+        ax[1].contour(R[0, :], Z[:, 0], OmegaUH, [OmegaInj])
+        ax[1].set_title("$\Omega_{UH}$")
+        ax[1].set_xlabel("R [m]")
+        ax[1].set_ylabel("Z [m]")
+        ax[2].contour(R[0, :], Z[:, 0], OmegaLH, [OmegaInj])
+        ax[2].set_title("$\Omega_{LH}$")
+        ax[2].set_xlabel("R [m]")
+        ax[2].set_ylabel("Z [m]")
+        plt.show()
+        plt.contourf(R[0, :], Z[:, 0], OmegaUH)
+        plt.colorbar()
+        fig.tight_layout()
+
+    def PlotCutOff(self):
+        """Method for plotting of the cutoffs"""
+        OmegaInj, OmegaC1, OmegaC2, R, Z = (
+            self.OmegaInj,
+            self.OmegaC1,
+            self.OmegaC2,
+            self.Eq.R,
+            self.Eq.Z,
+        )
+        fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(10, 10))
+        ax[0].contour(R[0, :], Z[:, 0], OmegaC1, [OmegaInj])
+        ax[0].set_title("$\Omega_{C1}$")
+        ax[0].set_xlabel("R [m]")
+        ax[0].set_ylabel("Z [m]")
+        ax[1].contour(R[0, :], Z[:, 0], OmegaC2, [OmegaInj])
+        ax[1].set_title("$\Omega_{C2}$")
+        ax[1].set_xlabel("R [m]")
+        ax[1].set_ylabel("Z [m]")
+        fig.tight_layout()
+        plt.show()
+        plt.contourf(R[0, :], Z[:, 0], OmegaC2)
+        plt.colorbar()
+
+    def PlotResonancesMesh(self):
+        """Method for plotting of the resonances on the physical mesh"""
+        OmegaCE, OmegaUH, OmegaLH, R, Z, Grid, n, m, OmegaInj = (
+            self.OmegaCE,
+            self.OmegaUH,
+            self.OmegaLH,
+            self.Eq.R,
+            self.Eq.Z,
+            self.Mesh.Mesh,
+            self.Mesh.n,
+            self.Mesh.m,
+            self.OmegaInj,
+        )
+        OmegaCEInterp = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], OmegaCE)
+        OmegaUHInterp = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], OmegaUH)
+        OmegaLHInterp = scipy.interpolate.RectBivariateSpline(Z[:, 0], R[0, :], OmegaLH)
+        Rc, Zc = Grid[:, 2], Grid[:, 3]
+        OmegaCEGrid = np.zeros(n * (m + 2))
+        OmegaUHGrid = np.zeros(n * (m + 2))
+        OmegaLHGrid = np.zeros(n * (m + 2))
+        for ii in range(0, Rc.size):
+            OmegaCEGrid[ii] = OmegaCEInterp(Zc[ii], Rc[ii])
+            OmegaUHGrid[ii] = OmegaUHInterp(Zc[ii], Rc[ii])
+            OmegaLHGrid[ii] = OmegaLHInterp(Zc[ii], Rc[ii])
+        OmegaCEGrid = OmegaCEGrid.reshape(m + 2, n)
+        OmegaUHGrid = OmegaUHGrid.reshape(m + 2, n)
+        OmegaLHGrid = OmegaLHGrid.reshape(m + 2, n)
+        it = 0
+        Grid = np.delete(Grid, (1), axis=1)
+        Grid = np.delete(Grid, (0), axis=1)
+        Shape = Grid.shape
+        A = np.zeros(Shape[0] * (Shape[1] - 2))
+        for ii in range(0, Shape[0]):
+            for jj in range(0, Shape[1] - 2):
+                A[it] = Grid[ii, jj]
+                it = it + 1
+        x = A[0 : A.size : 2]
+        y = A[1 : A.size : 2]
+        Points = n * 5
+        Rc = Rc.reshape(m + 2, n)
+        Zc = Zc.reshape(m + 2, n)
+        fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(10, 10))
+        ax[0].contour(Rc, Zc, OmegaCEGrid, [OmegaInj])
+        ax[0].set_title("$\Omega_{CE}$")
+        ax[0].set_xlabel("R [m]")
+        ax[0].set_ylabel("Z [m]")
+        for ii in range(0, m + 3):
+            ax[0].plot(
+                x[ii * n * 5 + 1 : Points], y[ii * n * 5 + 1 : Points], "black", linewidth=0.5
+            )
+            Points = Points + n * 5
+        Points = n * 5
+        ax[1].contour(Rc, Zc, OmegaUHGrid, [OmegaInj])
+        ax[1].set_title("$\Omega_{UH}$")
+        ax[1].set_xlabel("R [m]")
+        ax[1].set_ylabel("Z [m]")
+        for ii in range(0, m + 3):
+            ax[1].plot(
+                x[ii * n * 5 + 1 : Points], y[ii * n * 5 + 1 : Points], "black", linewidth=0.5
+            )
+            Points = Points + n * 5
+        Points = n * 5
+        ax[2].contour(Rc, Zc, OmegaLHGrid, [OmegaInj])
+        ax[2].set_title("$\Omega_{LH}$")
+        ax[2].set_xlabel("R [m]")
+        ax[2].set_ylabel("Z [m]")
+        for ii in range(0, m + 3):
+            ax[2].plot(
+                x[ii * n * 5 + 1 : Points], y[ii * n * 5 + 1 : Points], "black", linewidth=0.5
+            )
+            Points = Points + n * 5
+        Points = n * 5
+        plt.show()
+        fig.tight_layout()
+
 
 class Sources:
-	"""Class for the definition of the source input """
-	def __init__(self, RadialDensity, AxialDensity, Mesh, Resonances, sigma):
-		self.Grid = Mesh
-		self.Res = Resonances
-		self.zmin = Resonances.ZResPosition - sigma
-		self.zmax = Resonances.ZResPosition + sigma
-		self.RadialDensity = RadialDensity
-		self.AxialDensity = AxialDensity 
-		self.RadialPoints = Sources.ComputeRadialPoints(self)
-		self.AxialPoints= Sources.ComputeAxialPoints(self)
-	def ComputeRadialPoints(self):
-		AxialResPosition, Mesh, n, zmin, zmax= self.Res.ZResPosition, self.Grid.Mesh, self.Grid.n, self.zmin, self.zmax
-		Shape = np.shape(Mesh)
-		Toll = AxialResPosition * 1.1
-		zMin = AxialResPosition - Toll
-		zMax = AxialResPosition + Toll 
-		RcentrePoints = Mesh[0 : Shape[0], 2]
-		ZcentrePoints = Mesh[0 : Shape[0], 3]
-		ZonAxis = ZcentrePoints[0 : n]
-		IndInf = np.max(np.where(ZonAxis >= zmin))
-		IndMax = np.min(np.where(ZonAxis <= zmax))
-		print(IndInf)
-		zMinSor = ZonAxis[IndInf]
-		zMaxSor = ZonAxis[IndMax]
-		IndInf = np.where(zMinSor == ZcentrePoints)
-		IndSup = np.where(zMaxSor == ZcentrePoints)
-		RadialPoints = (RcentrePoints[IndInf] + RcentrePoints[IndSup]) / 2
-		RadialPoints = np.append(-RadialPoints[0], RadialPoints)
-		return RadialPoints
-	def ComputeAxialPoints(self):
-		n = self.Grid.n
-		AxialPoints = np.linspace(0, 1, n)
-		return AxialPoints
-	def WriteSource(self):
-		RadialPoints, AxialPoints = self.RadialPoints, self.AxialPoints
-		RadialValues = self.RadialDensity(RadialPoints)
-		AxialValues = self.AxialDensity(AxialPoints)
-		l = np.size(RadialPoints)
+    """Class for the definition of the source input"""
 
+    def __init__(self, RadialDensity, AxialDensity, Mesh, Resonances, sigma):
+        self.Grid = Mesh
+        self.Res = Resonances
+        self.zmin = Resonances.ZResPosition - sigma
+        self.zmax = Resonances.ZResPosition + sigma
+        self.RadialDensity = RadialDensity
+        self.AxialDensity = AxialDensity
+        self.RadialPoints = Sources.ComputeRadialPoints(self)
+        self.AxialPoints = Sources.ComputeAxialPoints(self)
 
+    def ComputeRadialPoints(self):
+        AxialResPosition, Mesh, n, zmin, zmax = (
+            self.Res.ZResPosition,
+            self.Grid.Mesh,
+            self.Grid.n,
+            self.zmin,
+            self.zmax,
+        )
+        Shape = np.shape(Mesh)
+        Toll = AxialResPosition * 1.1
+        zMin = AxialResPosition - Toll
+        zMax = AxialResPosition + Toll
+        RcentrePoints = Mesh[0 : Shape[0], 2]
+        ZcentrePoints = Mesh[0 : Shape[0], 3]
+        ZonAxis = ZcentrePoints[0:n]
+        IndInf = np.max(np.where(ZonAxis >= zmin))
+        IndMax = np.min(np.where(ZonAxis <= zmax))
+        print(IndInf)
+        zMinSor = ZonAxis[IndInf]
+        zMaxSor = ZonAxis[IndMax]
+        IndInf = np.where(zMinSor == ZcentrePoints)
+        IndSup = np.where(zMaxSor == ZcentrePoints)
+        RadialPoints = (RcentrePoints[IndInf] + RcentrePoints[IndSup]) / 2
+        RadialPoints = np.append(-RadialPoints[0], RadialPoints)
+        return RadialPoints
 
+    def ComputeAxialPoints(self):
+        n = self.Grid.n
+        AxialPoints = np.linspace(0, 1, n)
+        return AxialPoints
+
+    def WriteSource(self):
+        RadialPoints, AxialPoints = self.RadialPoints, self.AxialPoints
+        RadialValues = self.RadialDensity(RadialPoints)
+        AxialValues = self.AxialDensity(AxialPoints)
+        l = np.size(RadialPoints)

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-from Equilibrium import *
+from Equilibrium import Equilibrium, Mesh, PlotEquilibrium
 
 r1 = 1.0e-8
 r2 = 0.125
@@ -9,6 +9,6 @@ Nz = 105
 Eq = Equilibrium(r1, r2, z1, z2, Nr, Nz)
 PlotEq = PlotEquilibrium(Eq)
 PlotEq.PlotPsiContour()
-Mesh = Mesh(Eq, 50, 200, 0.125)
-Mesh.PlotMesh()
-Mesh.WriteMesh()
+mesh = Mesh(Eq, 50, 200, 0.125)
+mesh.PlotMesh()
+mesh.WriteMesh()

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,8 @@
 from Equilibrium import *
-r1 = 1.0E-8 
-r2 = 0.125 
-z1 = -1.01 
+
+r1 = 1.0e-8
+r2 = 0.125
+z1 = -1.01
 z2 = 1.01
 Nr = 105
 Nz = 105


### PR DESCRIPTION
  ## Summary
  Clean up all 610 ruff findings surfaced by the newly added lint config, in three reviewable steps.

  - `c7d0c0c` — `ruff format` (whitespace/tabs only, ~564 findings, zero logic change)
  - `9f0fbc0` — `ruff check --fix` (14 safe auto-fixes: raw strings for LaTeX, unused imports, f-string, sorted imports, obsolete utf-8 header)
  - `e6cec94` — manual fixes for the remaining 32 findings (star imports → explicit, unused tuple-unpacking, `lambda` → `def`, `np.trapz` → `np.trapezoid`)

  **Result:** `uv run ruff check .` → all checks pass; `uv run pytest` → 2 passed.

  ## Notable changes worth reviewing
  - `main.py`: replaced `from Equilibrium import *` with explicit imports; renamed local `Mesh` → `mesh` (was shadowing the class)
  - `ChargedMotion.py`: replaced `from Equilibrium import *` with `from Equilibrium import Equilibrium`; added explicit `import scipy.interpolate` (was previously leaking via star
   import)
  - `Equilibrium.py:141`: `np.trapz` → `np.trapezoid` (required on NumPy 2.x)
  - `Equilibrium.py:279`: `func = lambda x: ...` → `def func(x): ...`
  - `Sources.WriteSource`: WIP placeholder preserved with `# noqa: F841` and a TODO — the function body is incomplete upstream

  ## Out of scope (deliberate follow-ups)
  - Replace deprecated `numpy.matlib.repmat`/`repeat` in `Equilibrium.py` (7 call sites) — semantic refactor, own PR
  - Wrap the top-level demo block in `ChargedMotion.py:169` under `if __name__ == "__main__":` so the module becomes importable and can be tested

  ## Test plan
  - [x] `uv run ruff check .` passes locally
  - [x] `uv run pytest` passes locally
  - [ ] Reviewer runs the same locally